### PR TITLE
Increased max array size length for sending longer raw periods

### DIFF
--- a/IRLib2/IRLibGlobals.h
+++ b/IRLib2/IRLibGlobals.h
@@ -24,7 +24,7 @@
  * so that the index into the array can remain 8 bits. This library can handle larger 
  * arrays however it will make your code longer in addition to taking more RAM.
  */
-#define RECV_BUF_LENGTH 100
+#define RECV_BUF_LENGTH 140
 #if (RECV_BUF_LENGTH > 255)
 	typedef uint16_t bufIndex_t;
 #else

--- a/IRLibProtocols/IRLib_HashRaw.h
+++ b/IRLibProtocols/IRLib_HashRaw.h
@@ -38,9 +38,9 @@
  */
 class IRsendRaw: public virtual IRsendBase {
   public:
-    void send(uint16_t *buf, uint8_t len, uint8_t khz) {
+    void send(uint16_t *buf, uint16_t len, uint8_t khz) {
       enableIROut(khz);
-      for (uint8_t i = 0; i < len; i++) {
+      for (uint16_t i = 0; i < len; i++) {
         if (i & 1) {
           space(buf[i]);
         } 


### PR DESCRIPTION
Increased the maximum array size to pass to IRsendRaw.send to be able to use long raw sequences. This is needed to work with air conditioner IR-controls which have long command sequences.