### PR TITLE
Fixes #26: Increasing RECV_BUF_LENGTH over 256 caused endless loop if…

### DIFF
--- a/IRLib2/IRLibRecvBase.cpp
+++ b/IRLib2/IRLibRecvBase.cpp
@@ -85,7 +85,7 @@ bool IRrecvBase::getResults(const uint16_t timePerTick) {
 //If the receiver counts time intervals rather than actual microseconds we will multiply
 //the data by timePerTick. It also adjusts the data by adding or subtracting the
 //markExcess value. See the documentation on markExcess for details.
-  for(uint8_t i=0; i<recvGlobal.decodeLength; i++) {
+  for(bufIndex_t i=0; i<recvGlobal.decodeLength; i++) {
     recvGlobal.decodeBuffer[i]=Source[i]*timePerTick + ( (i % 2)? -markExcess:markExcess);
   }
   //Now that the decoder has its data it doesn't want any more until it tells you.


### PR DESCRIPTION
… actual received number of samples was bigger than 256.

Closes #26