### PR TITLE
Longer raw messages sending

### DIFF
--- a/IRLibProtocols/IRLib_HashRaw.h
+++ b/IRLibProtocols/IRLib_HashRaw.h
@@ -38,9 +38,9 @@
  */
 class IRsendRaw: public virtual IRsendBase {
   public:
-    void send(uint16_t *buf, uint8_t len, uint8_t khz) {
+    void send(uint16_t *buf, uint16_t len, uint8_t khz) {
       enableIROut(khz);
-      for (uint8_t i = 0; i < len; i++) {
+      for (uint16_t i = 0; i < len; i++) {
         if (i & 1) {
           space(buf[i]);
         } 


### PR DESCRIPTION
With len being uint8_t only up to 255 bit messages can be send. This way you can send much larger messages (necessary for sending Mitsubishi ac commands for instance)