### PR TITLE
Added ESP32 support

### DIFF
--- a/IRLibFreq/IRLibFreq.cpp
+++ b/IRLibFreq/IRLibFreq.cpp
@@ -8,7 +8,9 @@
  * passing the interrupt number.
  */
 #include <Arduino.h>
-#include <avr/interrupt.h>
+#if !defined (__SAMD21G18A__) && !defined(ESP32)
+  #include <avr/interrupt.h>
+#endif
 #include "IRLibFreq.h"
 
 volatile FREQUENCY_BUFFER_TYPE *IRfreqTimes;

--- a/IRLibProtocols/IRLibESP32.cpp
+++ b/IRLibProtocols/IRLibESP32.cpp
@@ -14,14 +14,18 @@
 #include "IRLibHardware.h"
 #include "IRLibESP32.h"
 
-hw_timer_t *esp32Timer;
+hw_timer_t *esp32Timer = NULL;
 
 void startESP32Timer() {
-    timerAlarmEnable(esp32Timer);
+    if (esp32Timer != NULL) {
+        timerAlarmEnable(esp32Timer);
+    }
 }
 
 void stopESP32Timer() {
-    timerAlarmDisable(esp32Timer);
+    if (esp32Timer != NULL) {
+        timerAlarmDisable(esp32Timer);
+    }
 }
 
 void initializeESP32TimerInterrupt() {

--- a/IRLibProtocols/IRLibESP32.cpp
+++ b/IRLibProtocols/IRLibESP32.cpp
@@ -1,0 +1,37 @@
+/* IRLibESP32.cpp
+ * Part of IRLib Library for Arduino receiving, decoding, and sending
+ * infrared signals. See COPYRIGHT.txt and LICENSE.txt for more information.
+ *
+ * This type of content is normally stored in IRLibHardware.h but we have 
+ * moved at her because the ESP32 support is significantly different than the
+ * AVR 8-bit hardware support. Separating it out into a separate file
+ * will make it easier to include comments and to maintain the code.
+ */
+
+/* See IRLibESP32.h for details about this implementation.
+ */
+#if defined (ESP32)
+#include "IRLibHardware.h"
+#include "IRLibESP32.h"
+
+hw_timer_t *esp32Timer;
+
+void startESP32Timer() {
+    timerAlarmEnable(esp32Timer);
+}
+
+void stopESP32Timer() {
+    timerAlarmDisable(esp32Timer);
+}
+
+void initializeESP32TimerInterrupt() {
+    // Configure timer 1 (0-3) with the prescaler/divider
+    // so that every tick is one microsecond.
+    esp32Timer = timerBegin(1, (SYSCLOCK / 1000000), true);
+    // Attach timer to the interrupt function.
+    timerAttachInterrupt(esp32Timer, &onESP32Timer, true);
+    // Set the interval time of the timer.
+    timerAlarmWrite(esp32Timer, USEC_PER_TICK, true);
+}
+
+#endif

--- a/IRLibProtocols/IRLibESP32.h
+++ b/IRLibProtocols/IRLibESP32.h
@@ -1,0 +1,38 @@
+/* IRLibESP32.h
+ * Part of IRLib Library for Arduino receiving, decoding, and sending
+ * infrared signals. See COPYRIGHT.txt and LICENSE.txt for more information.
+ *
+ * This type of content is normally stored in IRLibHardware.h but we have 
+ * moved at her because the ESP32 support is significantly different than the
+ * AVR 8-bit hardware support. Separating it out into a separate file
+ * will make it easier to include comments and to maintain the code.
+ */
+
+#ifndef IRLibESP32_h
+#define IRLibESP32_h
+
+// Output GPIO pin for IR LED. Any GPIO pin which can be output may be used.
+#define IR_SEND_ESP32           26
+    
+#define IR_SEND_PWM_START       ledcAttachPin(IR_SEND_ESP32, 1);
+#define IR_SEND_MARK_TIME(time) IRLibDelayUSecs(time)
+#define IR_SEND_PWM_STOP        ledcDetachPin(IR_SEND_ESP32);
+// Setup (LED) PWM channel 1 (0-15) with 8-bits resolution.
+// Set the duty cycle to 50%.
+#define IR_SEND_CONFIG_KHZ(val) ({ \
+                                    ledcSetup(1, val * 1000, 8); \
+                                    ledcWrite(1, 128); \
+                                })
+#define IR_SEND_PWM_PIN	        IR_SEND_ESP32
+
+#define IR_RECV_ENABLE_INTR     startESP32Timer()
+#define IR_RECV_DISABLE_INTR    stopESP32Timer()
+#define IR_RECV_INTR_NAME       void IRAM_ATTR onESP32Timer()
+#define IR_RECV_CONFIG_TICKS()  initializeESP32TimerInterrupt()
+
+void IRAM_ATTR onESP32Timer(void);
+void startESP32Timer(void);
+void stopESP32Timer(void);
+void initializeESP32TimerInterrupt(void);
+
+#endif

--- a/IRLibProtocols/IRLibHardware.h
+++ b/IRLibProtocols/IRLibHardware.h
@@ -79,17 +79,22 @@
   
 /* Arduino Zero, M0, M0 Pro, Feather M0 etc. */
 #elif defined (__SAMD21G18A__) || defined(__SAMD21E18A__)
-// All of the settings can be found in IRLibSAMD21.h
-  #include "IRLibSAMD21.h"
+	// All of the settings can be found in IRLibSAMD21.h
+	#include "IRLibSAMD21.h"
 
 /* Adafruit Metro M4, Feather M4 and any other SAMD51 boards */
 #elif defined (__SAMD51__) 
-// All of the settings can be found in IRLibSAMD51.h
-  #include "IRLibSAMD51.h"
+	// All of the settings can be found in IRLibSAMD51.h
+	#include "IRLibSAMD51.h"
 
 /* Pinoccio Scout */
 #elif defined(__AVR_ATmega256RFR2__)
 	#define IR_SEND_TIMER3		3
+
+/* ESP32 */
+#elif defined(ESP32)
+	// All of the settings can be found in IRLibESP32.h
+	#include "IRLibESP32.h"
 
 /* Arduino Duemilanove, Diecimila, LilyPad, Mini, Fio, etc */
 #else
@@ -134,7 +139,9 @@
 
 // Miscellaneous defines needed for computations below
 #ifdef F_CPU
-#define SYSCLOCK F_CPU     // main Arduino clock
+#define SYSCLOCK F_CPU     // clock setting from compiler
+#elif defined(ESP32)
+#define SYSCLOCK 80000000  // main ESP32 clock
 #else
 #define SYSCLOCK 16000000  // main Arduino clock
 #endif
@@ -158,8 +165,10 @@
 	#elif defined(IR_SEND_TIMER5)
 		#define IR_RECV_TIMER5
 	#elif defined(__SAMD21G18A__) || defined(__SAMD21E18A__) || defined(__SAMD51__)//handle this one a little differently
-    #define IR_RECV_TC3
-  #else
+		#define IR_RECV_TC3
+	#elif defined(ESP32)
+		#define IR_RECV_ESP32
+	#else
 		#error "Unable to set IR_RECV_TIMER"
 	#endif
 #endif
@@ -266,7 +275,15 @@
 	#define IR_SEND_PWM_START 
 	#define IR_SEND_MARK_TIME(time)
 	#define IR_SEND_PWM_STOP 
-  #define IR_SEND_PWM_PIN	
+	#define IR_SEND_PWM_PIN	
+	#define IR_SEND_CONFIG_KHZ(val) 
+ */
+#elif defined(IR_SEND_ESP32) && defined(IRLibESP32_h)
+/* All of these definitions have been moved to IRLibESP32.h
+	#define IR_SEND_PWM_START 
+	#define IR_SEND_MARK_TIME(time)
+	#define IR_SEND_PWM_STOP 
+	#define IR_SEND_PWM_PIN	
 	#define IR_SEND_CONFIG_KHZ(val) 
  */
 #else // unknown timer
@@ -339,7 +356,14 @@
 #elif defined(IRLibSAMD21_h) || defined(IRLibSAMD51_h) //for SAMD 21 or 51
 /* All of these definitions have been moved to IRLibSAMD21.h
 	#define IR_RECV_ENABLE_INTR 
-  #define IR_RECV_DISABLE_INTR
+	#define IR_RECV_DISABLE_INTR
+	#define IR_RECV_INTR_NAME
+	#define IR_RECV_CONFIG_TICKS()
+ */
+#elif defined(IR_RECV_ESP32) && defined(IRLibESP32_h)
+/* All of these definitions have been moved to IRLibESP32.h
+	#define IR_RECV_ENABLE_INTR 
+	#define IR_RECV_DISABLE_INTR
 	#define IR_RECV_INTR_NAME
 	#define IR_RECV_CONFIG_TICKS()
  */

--- a/IRLibProtocols/IRLibSAMD21.h
+++ b/IRLibProtocols/IRLibSAMD21.h
@@ -85,8 +85,8 @@
   //Settings for Arduino MKR 1000.
   //Default is 6. Only 0-12 or 18-21 (Note: 18-21 is also A3-A6)
   #define IR_SEND_PWM_PIN 6
-  #if ((IR_SEND_PWM_PIN > 21) || ( (IR_SEND_PWM_PIN > 12) && (IR_SEND_PWM_PIN  18)) )
-    #error "Unsupported output pin on Arduino MKR 1000.
+  #if ((IR_SEND_PWM_PIN > 21) || ( (IR_SEND_PWM_PIN > 12) && (IR_SEND_PWM_PIN < 18)) )
+    #error "Unsupported output pin on Arduino MKR 1000." //issue 56 error?
   #endif
 #elif (defined(ARDUINO_SAMD_FEATHER_M0) || defined(ARDUINO_SAMD_FEATHER_M0_EXPRESS) )
   //Settings for Adafruit Feather M0 or Adafruit Feather M0 Express
@@ -121,7 +121,7 @@
   #if ( ( (IR_SEND_PWM_PIN > 21) && (IR_SEND_PWM_PIN < 27) ) \
        || (IR_SEND_PWM_PIN > 28) || (IR_SEND_PWM_PIN == 14)  \
 	   || (IR_SEND_PWM_PIN == 15) )
-    #error "Unsupported output pin on Arduino M0 Pro
+    #error "Unsupported output pin on Arduino M0 Pro"
   #endif
 #elif defined (ARDUINO_SAMD_ZERO) 
   //Settings for Arduino Zero 
@@ -130,7 +130,7 @@
   #if ( (IR_SEND_PWM_PIN > 24) \
    || ( (IR_SEND_PWM_PIN > 13) && (IR_SEND_PWM_PIN < 17)) \
    || (IR_SEND_PWM_PIN == 19) )
-    #error "Unsupported output pin on Arduino Zero
+    #error "Unsupported output pin on Arduino Zero"
   #endif
 #else //Other generic SAMD 21 boards 
   //Default is 9.

--- a/IRLibProtocols/IRLibSAMD51.h
+++ b/IRLibProtocols/IRLibSAMD51.h
@@ -28,7 +28,7 @@
   //Default is 9. Available 0-13
   #define IR_SEND_PWM_PIN 9
   #if (IR_SEND_PWM_PIN > 13)
-    #error "Unsupported output pin on Adafruit Metro M4
+    #error "Unsupported output pin on Adafruit Metro M4"
   #endif
 #else //Other generic SAMD 51 boards 
   //Default is 9.

--- a/IRLibRecv/IRLibRecv.cpp
+++ b/IRLibRecv/IRLibRecv.cpp
@@ -12,7 +12,7 @@
  
 #include "IRLibRecv.h"
 #include "IRLibHardware.h" //needed for IRLib_didIROut
-#if !defined (__SAMD21G18A__)
+#if !defined (__SAMD21G18A__) && !defined(ESP32)
   #include <avr/interrupt.h>
 #endif
   


### PR DESCRIPTION
This PR adds support for the ESP32 module and fixes #48. The changes are tested on an ESP32 Dev Module.

The default IR send pin is 26, but this can be changed in "IRLibESP32.h".